### PR TITLE
Use wrapping operations for a case that can overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,8 @@ impl Parser {
 					c = s.peek();
 					
 					while c >= C0 && c <= C9 {
-						L = L * 10 + c - C0;
+						// The next line is the integer wrapping equivalent of `L = L * 10 + c - C0`;
+						L = u32::wrapping_sub(u32::wrapping_add(u32::wrapping_mul(L, 10), c), C0);
 						
 						s.bump();
 						c = s.peek();


### PR DESCRIPTION
This line can cause an integer overflow when fuzzing NowJson, which triggers a panic when compiling in debug mode.